### PR TITLE
Add retryableStatusCodes field to subscription

### DIFF
--- a/src/main/java/de/telekom/horizon/comet/cache/CallbackUrlCache.java
+++ b/src/main/java/de/telekom/horizon/comet/cache/CallbackUrlCache.java
@@ -51,7 +51,9 @@ public class CallbackUrlCache {
         }
 
         return subscription.map(subscriptionResource -> new DeliveryTargetInformation
-                (subscriptionResource.getSpec().getSubscription().getCallback(), subscriptionResource.getSpec().getSubscription().isCircuitBreakerOptOut()));
+                (subscriptionResource.getSpec().getSubscription().getCallback(),
+                        subscriptionResource.getSpec().getSubscription().isCircuitBreakerOptOut(),
+                        subscriptionResource.getSpec().getSubscription().getRetryableStatusCodes()));
 
     }
 }

--- a/src/main/java/de/telekom/horizon/comet/cache/DeliveryTargetInformation.java
+++ b/src/main/java/de/telekom/horizon/comet/cache/DeliveryTargetInformation.java
@@ -9,6 +9,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 /**
  * The {@code DeliveryTargetInformation} class represents properties associated with callbackUrls, including the url
  * itself and an indicator to active or deactivate the circuit breaker.
@@ -28,5 +30,10 @@ public class DeliveryTargetInformation {
      * A boolean flag indicating whether the associated callback should active or deactivate the circuit breaker.
      */
     private boolean optOutCircuitBreaker;
+
+    /**
+     * A list of status codes that should be retried.
+     */
+    private List<Integer> retryableStatusCodes;
 
 }

--- a/src/main/java/de/telekom/horizon/comet/model/DeliveryTaskRecord.java
+++ b/src/main/java/de/telekom/horizon/comet/model/DeliveryTaskRecord.java
@@ -8,6 +8,7 @@ import brave.Span;
 import brave.internal.Nullable;
 import de.telekom.eni.pandora.horizon.model.event.SubscriptionEventMessage;
 import de.telekom.eni.pandora.horizon.model.meta.HorizonComponentId;
+import de.telekom.horizon.comet.cache.CallbackUrlCache;
 import de.telekom.horizon.comet.service.DeliveryResultListener;
 import de.telekom.horizon.comet.service.DeliveryTaskFactory;
 import org.springframework.context.ApplicationContext;
@@ -19,6 +20,7 @@ public record DeliveryTaskRecord (
         int retryCount,
         DeliveryResultListener deliveryResultListener,
         DeliveryTaskFactory deliveryTaskFactory,
+        CallbackUrlCache callbackUrlCache,
         @Nullable Span deliverySpan,
         HorizonComponentId messageSource,
         ApplicationContext context

--- a/src/main/java/de/telekom/horizon/comet/service/DeliveryService.java
+++ b/src/main/java/de/telekom/horizon/comet/service/DeliveryService.java
@@ -126,7 +126,7 @@ public class DeliveryService implements DeliveryResultListener {
         var callbackUrlOrEmptyStr = getCallbackUrlOrEmptyStr(subscriptionEventMessage);
         // if callbackUrl is empty, we throw an CallbackUrlNotFoundException later, which gets handled
 
-        DeliveryTaskRecord deliveryTaskRecord = new DeliveryTaskRecord(subscriptionEventMessage, callbackUrlOrEmptyStr, 0, 0, this, deliveryTaskFactory, null, messageSource, null);
+        DeliveryTaskRecord deliveryTaskRecord = new DeliveryTaskRecord(subscriptionEventMessage, callbackUrlOrEmptyStr, 0, 0, this, deliveryTaskFactory, callbackUrlCache, null, messageSource, null);
         var deliveryTask = deliveryTaskFactory.createNew(deliveryTaskRecord);
 
         // Do not wait for thread
@@ -271,7 +271,7 @@ public class DeliveryService implements DeliveryResultListener {
                 eventUuid, backoffInterval, retryCount, cometConfig.getMaxRetries());
 
 
-        DeliveryTaskRecord deliveryTaskRecord = new DeliveryTaskRecord(subscriptionEventMessage, callbackUrlOrEmptyStr, backoffInterval, retryCount, this, deliveryTaskFactory, deliverySpan, deliveryResult.messageSource(), null);
+        DeliveryTaskRecord deliveryTaskRecord = new DeliveryTaskRecord(subscriptionEventMessage, callbackUrlOrEmptyStr, backoffInterval, retryCount, this, deliveryTaskFactory, callbackUrlCache, deliverySpan, deliveryResult.messageSource(), null);
         var redeliverTask = deliveryTaskFactory.createNew(deliveryTaskRecord);
         redeliveryTaskExecutor.submit(tracer.withCurrentTraceContext(redeliverTask));
         return true;

--- a/src/test/java/de/telekom/horizon/comet/client/RestClientTest.java
+++ b/src/test/java/de/telekom/horizon/comet/client/RestClientTest.java
@@ -7,6 +7,7 @@ package de.telekom.horizon.comet.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.telekom.eni.pandora.horizon.tracing.HorizonTracer;
 import de.telekom.horizon.comet.auth.OAuth2TokenCache;
+import de.telekom.horizon.comet.cache.CallbackUrlCache;
 import de.telekom.horizon.comet.config.CometConfig;
 import de.telekom.horizon.comet.exception.CallbackException;
 import de.telekom.horizon.comet.test.utils.AbstractIntegrationTest;
@@ -44,6 +45,8 @@ class RestClientTest extends AbstractIntegrationTest {
     @Mock
     OAuth2TokenCache oAuth2TokenCache;
     @Mock
+    CallbackUrlCache callbackUrlCache;
+    @Mock
     CloseableHttpClient closeableHttpClient;
     @Mock
     CloseableHttpResponse closeableHttpResponse;
@@ -59,7 +62,7 @@ class RestClientTest extends AbstractIntegrationTest {
         when(cometConfig.getHeaderPropagationBlacklist()).thenReturn(List.of("x-spacegate-token","authorization","content-length","host","accept.*","x-forwarded.*"));
         when(closeableHttpResponse.getStatusLine()).thenReturn(statusLine);
         when(closeableHttpClient.execute(any())).thenReturn(closeableHttpResponse);
-        this.restClient = spy(new RestClient(cometConfig, horizonTracer, oAuth2TokenCache, closeableHttpClient, new ObjectMapper(), context));
+        this.restClient = spy(new RestClient(cometConfig, horizonTracer, oAuth2TokenCache, callbackUrlCache, closeableHttpClient, new ObjectMapper(), context));
     }
 
     @ParameterizedTest(name = "Check Header for {0}")

--- a/src/test/java/de/telekom/horizon/comet/service/CircuitBreakerTests.java
+++ b/src/test/java/de/telekom/horizon/comet/service/CircuitBreakerTests.java
@@ -55,7 +55,7 @@ class CircuitBreakerTests extends AbstractIntegrationTest {
         final String callbackPath = "/callbacktest2";
 
         when(callbackUrlCache.getDeliveryTargetInformation(any())).thenReturn(Optional.of(
-                new DeliveryTargetInformation(wireMockServer.baseUrl() + callbackPath, false)));
+                new DeliveryTargetInformation(wireMockServer.baseUrl() + callbackPath, false, null)));
 
         wireMockServer.stubFor(
                 post(callbackPath).willReturn(aResponse().withStatus(HttpStatus.valueOf(status).value()))
@@ -104,7 +104,7 @@ class CircuitBreakerTests extends AbstractIntegrationTest {
         final String callbackPath = "/callbacktest3";
 
         when(callbackUrlCache.getDeliveryTargetInformation(any())).thenReturn(Optional.of(
-                new DeliveryTargetInformation(wireMockServer.baseUrl() + callbackPath, true)));
+                new DeliveryTargetInformation(wireMockServer.baseUrl() + callbackPath, true, null)));
 
         wireMockServer.stubFor(
                 post(callbackPath).willReturn(aResponse().withStatus(HttpStatus.valueOf(status).value()))
@@ -152,7 +152,7 @@ class CircuitBreakerTests extends AbstractIntegrationTest {
         final String callbackPath = "/callbacktest5";
 
         when(callbackUrlCache.getDeliveryTargetInformation(any())).thenReturn(Optional.of(
-                new DeliveryTargetInformation(wireMockServer.baseUrl() + callbackPath, true)));
+                new DeliveryTargetInformation(wireMockServer.baseUrl() + callbackPath, true, null)));
 
         wireMockServer.stubFor(
                 post(callbackPath).willReturn(aResponse().withStatus(HttpStatus.OK.value()))

--- a/src/test/java/de/telekom/horizon/comet/service/DeliveryErrorTests.java
+++ b/src/test/java/de/telekom/horizon/comet/service/DeliveryErrorTests.java
@@ -55,7 +55,7 @@ class DeliveryErrorTests extends AbstractIntegrationTest {
         final String blankCallback = "";
 
         when(callbackUrlCache.getDeliveryTargetInformation(any())).thenReturn(Optional.of(
-                new DeliveryTargetInformation(wireMockServer.baseUrl() + blankCallback, false)));
+                new DeliveryTargetInformation(wireMockServer.baseUrl() + blankCallback, false, null)));
 
         SubscriptionResource subscriptionResource = HorizonTestHelper.createDefaultSubscriptionResource("playground", getEventType());
         subscriptionResource.getSpec().getSubscription().setSubscriptionId(subscriptionId);
@@ -97,7 +97,7 @@ class DeliveryErrorTests extends AbstractIntegrationTest {
         final String callbackPath = "/duplicate";
 
         when(callbackUrlCache.getDeliveryTargetInformation(any())).thenReturn(Optional.of(
-                new DeliveryTargetInformation(wireMockServer.baseUrl() + callbackPath, false)));
+                new DeliveryTargetInformation(wireMockServer.baseUrl() + callbackPath, false, null)));
 
         wireMockServer.stubFor(
                 post(callbackPath).willReturn(aResponse().withStatus(HttpStatus.OK.value()))

--- a/src/test/java/de/telekom/horizon/comet/service/SimpleDeliveryIntegrationTest.java
+++ b/src/test/java/de/telekom/horizon/comet/service/SimpleDeliveryIntegrationTest.java
@@ -63,7 +63,7 @@ class SimpleDeliveryIntegrationTest extends AbstractIntegrationTest {
         final String traceId = UUID.randomUUID().toString();
 
         when(callbackUrlCache.getDeliveryTargetInformation(any())).thenReturn(Optional.of(
-                new DeliveryTargetInformation(wireMockServer.baseUrl() + callbackPath, false)));
+                new DeliveryTargetInformation(wireMockServer.baseUrl() + callbackPath, false, null)));
 
         wireMockServer.stubFor(
                 post(callbackPath).willReturn(aResponse().withStatus(HttpStatus.OK.value()))


### PR DESCRIPTION
This PR introduces a new field for subscriptions to allow the definition of retryable status codes.