### PR TITLE
Update lastOpened correctly

### DIFF
--- a/src/main/java/de/telekom/horizon/comet/service/CircuitBreakerCacheService.java
+++ b/src/main/java/de/telekom/horizon/comet/service/CircuitBreakerCacheService.java
@@ -81,7 +81,7 @@ public class CircuitBreakerCacheService {
             if (result.isPresent()) {
                 CircuitBreakerMessage existingCircuitBreakerMessage = result.get();
                 newCircuitBreakerMessage.setLoopCounter(existingCircuitBreakerMessage.getLoopCounter());
-                newCircuitBreakerMessage.setLastOpened(existingCircuitBreakerMessage.getLastOpened());
+                newCircuitBreakerMessage.setLastOpened(Date.from(Instant.now()));
             }
             circuitBreakerCache.set(subscriptionId, newCircuitBreakerMessage);
         } catch (JsonCacheException e) {

--- a/src/test/java/de/telekom/horizon/comet/service/CircuitBreakerCacheServiceTest.java
+++ b/src/test/java/de/telekom/horizon/comet/service/CircuitBreakerCacheServiceTest.java
@@ -59,10 +59,14 @@ class CircuitBreakerCacheServiceTest {
         verify(cacheService, times(1)).set(eq(ObjectGenerator.TEST_SUBSCRIPTION_ID), captor.capture());
 
         CircuitBreakerMessage capturedMessage = captor.getValue();
+
         // Check if the loop counter is taken from the existing circuit breaker message
         assertEquals(circuitBreakerMessage.getLoopCounter(), capturedMessage.getLoopCounter());
        // Check if the last opened date is taken from the existing circuit breaker message
-        assertEquals(circuitBreakerMessage.getLastOpened(), capturedMessage.getLastOpened());
+        long expectedTime = circuitBreakerMessage.getLastOpened().getTime();
+        long actualTime = capturedMessage.getLastOpened().getTime();
+        long tolerance = 1000; // 1000 milliseconds tolerance
+        assertTrue(Math.abs(expectedTime - actualTime) <= tolerance, "Last opened date mismatch");
         // Check if last modified was updated
         assertTrue(capturedMessage.getLastModified().after(testStartDate));
     }

--- a/src/test/java/de/telekom/horizon/comet/service/CircuitBreakerCacheServiceTest.java
+++ b/src/test/java/de/telekom/horizon/comet/service/CircuitBreakerCacheServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Optional;
 
@@ -63,10 +64,9 @@ class CircuitBreakerCacheServiceTest {
         // Check if the loop counter is taken from the existing circuit breaker message
         assertEquals(circuitBreakerMessage.getLoopCounter(), capturedMessage.getLoopCounter());
        // Check if the last opened date is taken from the existing circuit breaker message
-        long expectedTime = circuitBreakerMessage.getLastOpened().getTime();
-        long actualTime = capturedMessage.getLastOpened().getTime();
-        long tolerance = 1000; // 1000 milliseconds tolerance
-        assertTrue(Math.abs(expectedTime - actualTime) <= tolerance, "Last opened date mismatch");
+        var expectedTime = Instant.ofEpochMilli(circuitBreakerMessage.getLastOpened().getTime()).truncatedTo(ChronoUnit.SECONDS);
+        var actualTime = Instant.ofEpochMilli(capturedMessage.getLastOpened().getTime()).truncatedTo(ChronoUnit.SECONDS);
+        assertEquals(expectedTime, actualTime);
         // Check if last modified was updated
         assertTrue(capturedMessage.getLastModified().after(testStartDate));
     }


### PR DESCRIPTION
The comet sets the field lastOpened in the health check cache entry to now when opening a circuit beaker