### PR TITLE
Replace e2e latency percentile histogram with coarse SLO buckets

### DIFF
--- a/src/main/java/de/telekom/horizon/comet/config/CometMetrics.java
+++ b/src/main/java/de/telekom/horizon/comet/config/CometMetrics.java
@@ -56,7 +56,19 @@ public class CometMetrics {
                     .tag("clientId", messageSource.getClientId())
                     .minimumExpectedValue(Duration.ofMillis(10))
                     .maximumExpectedValue(Duration.ofHours(4))
-                    .publishPercentileHistogram()
+                    .serviceLevelObjectives(
+                            Duration.ofMillis(50),
+                            Duration.ofMillis(100),
+                            Duration.ofMillis(250),
+                            Duration.ofMillis(500),
+                            Duration.ofSeconds(1),
+                            Duration.ofMillis(2500),
+                            Duration.ofSeconds(5),
+                            Duration.ofSeconds(10),
+                            Duration.ofSeconds(30),
+                            Duration.ofMinutes(1),
+                            Duration.ofMinutes(5),
+                            Duration.ofMinutes(30))
                     .register(this.meterRegistry));
 
             long trustedEventStartTimeMillis = (Long) subscriptionEventMessage.getAdditionalFields().get(AdditionalFields.START_TIME_TRUSTED.getValue());


### PR DESCRIPTION
CometMetrics recorded horizon.e2e.tardis.latency and horizon.e2e.customer.latency via Timer.publishPercentileHistogram(), which emits Micrometer's full predefined bucket ladder (~95-276 le buckets) per (environment, clientId) series. Replace it with 12 explicit serviceLevelObjectives boundaries (50ms..30m), keeping the existing min/max expected-value bounds. Per-series bucket count drops to 13, preserving server-side histogram_quantile while cutting cardinality. The timerKey/HashMap behaviour is intentionally left unchanged.